### PR TITLE
state upgrade with nonce

### DIFF
--- a/params/extras/state_upgrade.go
+++ b/params/extras/state_upgrade.go
@@ -28,6 +28,7 @@ type StateUpgradeAccount struct {
 	Code          hexutil.Bytes               `json:"code,omitempty"`
 	Storage       map[common.Hash]common.Hash `json:"storage,omitempty"`
 	BalanceChange *math.HexOrDecimal256       `json:"balanceChange,omitempty"`
+	Nonce         *uint64                     `json:"nonce,omitempty"`
 }
 
 func (s *StateUpgrade) Equal(other *StateUpgrade) bool {

--- a/params/extras/state_upgrade_test.go
+++ b/params/extras/state_upgrade_test.go
@@ -160,7 +160,8 @@ func TestUnmarshalStateUpgradeJSON(t *testing.T) {
 					"blockTimestamp": 1677608400,
 					"accounts": {
 						"0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC": {
-							"balanceChange": "100"
+							"balanceChange": "100",
+							"nonce": 42
 						}
 					}
 				}
@@ -175,6 +176,7 @@ func TestUnmarshalStateUpgradeJSON(t *testing.T) {
 				StateUpgradeAccounts: map[common.Address]StateUpgradeAccount{
 					common.HexToAddress("0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"): {
 						BalanceChange: (*math.HexOrDecimal256)(big.NewInt(100)),
+						Nonce:         utils.NewUint64(42),
 					},
 				},
 			},

--- a/stateupgrade/state_upgrade.go
+++ b/stateupgrade/state_upgrade.go
@@ -33,12 +33,19 @@ func upgradeAccount(account common.Address, upgrade extras.StateUpgradeAccount, 
 		balanceChange, _ := uint256.FromBig((*big.Int)(upgrade.BalanceChange))
 		state.AddBalance(account, balanceChange)
 	}
-	if len(upgrade.Code) != 0 {
-		// if the nonce is 0, set the nonce to 1 as we would when deploying a contract at
-		// the address.
+
+	// Set nonce if explicitly provided
+	if upgrade.Nonce != nil {
+		state.SetNonce(account, *upgrade.Nonce)
+	} else if len(upgrade.Code) != 0 {
+		// If no explicit nonce is provided but code is being set, set the nonce to
+		// 1 as we would when deploying a contract at the address.
 		if isEIP158 && state.GetNonce(account) == 0 {
 			state.SetNonce(account, 1)
 		}
+	}
+
+	if len(upgrade.Code) != 0 {
 		state.SetCode(account, upgrade.Code)
 	}
 	for key, value := range upgrade.Storage {


### PR DESCRIPTION
## Why this should be merged

When migrating an existing blockchain to the Avalanche ecosystem and re-using the existing chain-id, the nonce is needed in order to preserve the correct nonce on the migration-target network. This is needed to ensure a complete migration and also preventing replay-attacks or hash-collisions.

## How this works

Adds nonce as an option to state upgrades

## How this was tested

Unit tests

## Need to be documented?

Yes, [this page](https://build.avax.network/docs/avalanche-l1s/upgrade/customize-avalanche-l1#network-upgrades-state-upgrades) needs to updated. I can provide a PR for that update also.

## Need to update RELEASES.md?

Please advice


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an optional nonce field for account state upgrades, allowing explicit control over numeric assignment during upgrades with refined handling when a value is provided.

- **Tests**
  - Extended tests to verify that state upgrade operations correctly process the nonce value, ensuring consistent and predictable behavior in various upgrade scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->